### PR TITLE
Add slack notification for in progress

### DIFF
--- a/.github/workflows/move-project-card.yml
+++ b/.github/workflows/move-project-card.yml
@@ -1,0 +1,33 @@
+name: Slack Notification for In Progress
+
+on:
+  project_card:
+    types:
+      - moved
+
+jobs:
+  send_slack_notification:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack if moved to In Progress
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          SENDER=${{ github.event.sender.login }}
+          ISSUE_DETAILS_JSON=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${{ github.event.project_card.content_url }}")
+          ISSUE_TITLE=$(echo "$ISSUE_DETAILS_JSON" | jq .title | tr -d '"')
+          ISSUE_URL=$(echo "$ISSUE_DETAILS_JSON" | jq .html_url | tr -d '"')
+          COLUMN_JSON=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/projects/columns/${{ github.event.project_card.column_id }}")
+          COLUMN_NAME=$(echo "$COLUMN_JSON" | jq .name | tr -d '"')
+          MESSAGE="Issue: '$ISSUE_TITLE' by $SENDER has been moved to $COLUMN_NAME."
+          
+          if [[ "$COLUMN_NAME" == "🏗 In progress" ]]; then
+            curl -X POST -H 'Content-type: application/json' \
+            --data "{
+              \"columnName\": \"$COLUMN_NAME\",
+              \"issueTitle\": \"$ISSUE_TITLE\",
+              \"issueUrl\": \"$ISSUE_URL\",
+              \"message\": \"$MESSAGE\",
+              \"sender\": \"$SENDER\"
+            }" $SLACK_WEBHOOK_URL
+          fi


### PR DESCRIPTION
Issue #53 

This adds a GitHub action to notify our Slack channel when a card is moved to "🏗 In progress" column.  

I generated a Slack Webhook URL via the Slack Workflows, and then added the `SLACK_WEBHOOK_URL` to our GitHub variables (see this repo's `settings` > `Secrets and variables` > `Actions` > `Variables`

(Hopefully it works 🤞 )

Resources in case anyone's curious:

- https://slack.com/help/articles/16962850225939-Build-a-workflow
- https://slack.com/help/articles/360041352714-Create-more-advanced-workflows-using-webhooks
- https://docs.github.com/en/actions/quickstart
- https://docs.github.com/en/actions/managing-issues-and-pull-requests/moving-assigned-issues-on-project-boards
- https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=moved#project_card
